### PR TITLE
Check existing nodes in ES before making POST requests

### DIFF
--- a/src/edu-sharing/create-folder-structure.js
+++ b/src/edu-sharing/create-folder-structure.js
@@ -26,18 +26,17 @@ async function createFolderForOcInstances(ocInstance, seriesData, authObj) {
       const limit = pLimit(CONF.es.settings.maxPendingPromises)
 
       for (let i = 1; i < modifiedSeriesData.length; i++) {
-        let found = false
+        let foundDir = false
         if (existingDirs.nodes) {
           for (const node of existingDirs.nodes) {
             if (node.name === modifyStringES(modifiedSeriesData[i].title)) {
               addNodeIdToSeries(node, i)
-              found = true
+              foundDir = true
             }
           }
         }
 
-        console.log(found)
-        if (found === false) {
+        if (foundDir === false) {
           // if (modifiedSeriesData[i].nodeId) continue
           if (modifiedSeriesData[i].type === 'metadata') continue
           requests.push(

--- a/src/edu-sharing/get-existing-nodes.js
+++ b/src/edu-sharing/get-existing-nodes.js
@@ -1,0 +1,89 @@
+'use strict'
+require('dotenv').config()
+require('axios-debug-log')
+const logger = require('node-file-logger')
+const CONF = require('../config/config')
+const axios = require('axios').default
+
+async function checkExistingDirs(ocInstance, authObj) {
+  let mainDirID = ''
+
+  // obj to store all existing ES diretories
+  let esDirectories = []
+
+  // get nodeID of home directory
+  await axios
+    .get(getUrlMainFolder(), getHeadersMetadata(authObj))
+    .then((response) => {
+      mainDirID = response.data.node.ref.id
+    })
+    .catch((err) => {
+      logger.Error('[ES API] ' + err)
+    })
+
+  // get nodeID of ocInstance directory if it exists
+  await axios
+    .get(getUrlChildFolders(mainDirID), getHeadersMetadata(authObj))
+    .then(async (response) => {
+      response.data.nodes.forEach(async (node) => {
+        if (node.name === ocInstance && node.isDirectory === true) {
+          // safe info
+          esDirectories = node
+        }
+      })
+
+      // get all existing subdirectories + nodeIDs
+      await axios
+        .get(getUrlChildFolders(esDirectories.ref.id), getHeadersMetadata(authObj))
+        .then(async (response) => {
+          // safe data
+          const subDirs = []
+          response.data.nodes.forEach((node) => {
+            if (node.isDirectory === true) {
+              subDirs.push(node)
+            }
+          })
+          esDirectories.nodes = subDirs
+        })
+        .catch((err) => {
+          logger.Error('[ES API] ' + err)
+        })
+    })
+    // if ocInstance directory does not exist
+    .catch((err) => {
+      if (err.response.status === 404) {
+        return esDirectories
+      }
+      logger.Error('[ES API] ' + err)
+    })
+
+  return esDirectories
+}
+
+function getUrlMainFolder() {
+  return CONF.es.host.url + CONF.es.routes.api + CONF.es.routes.baseFolder + '/-userhome-/metadata'
+}
+
+function getUrlChildFolders(nodeId) {
+  return (
+    CONF.es.host.url +
+    CONF.es.routes.api +
+    CONF.es.routes.baseFolder +
+    '/' +
+    nodeId +
+    '/children?maxItems=500&skipCount=0'
+  )
+}
+
+function getHeadersMetadata(authObj) {
+  return {
+    headers: {
+      Accept: 'application/json',
+      Authorization: authObj.type + ' ' + authObj.token_access
+    }
+  }
+}
+
+module.exports = {
+  checkExistingDirs
+}

--- a/src/edu-sharing/get-existing-nodes.js
+++ b/src/edu-sharing/get-existing-nodes.js
@@ -1,4 +1,5 @@
 'use strict'
+
 require('dotenv').config()
 require('axios-debug-log')
 const logger = require('node-file-logger')
@@ -49,14 +50,13 @@ async function checkExistingDirs(ocInstance, authObj) {
           logger.Error('[ES API] ' + err)
         })
     })
-    // if ocInstance directory does not exist
     .catch((err) => {
+      // if ocInstance directory does not exist
       if (err.response.status === 404) {
         return esDirectories
       }
       logger.Error('[ES API] ' + err)
     })
-
   return esDirectories
 }
 


### PR DESCRIPTION
**Do not merge this yet, it still needs some work!**

Refering to #15 the program currently tries to create new ES-nodes for every harvested episode and series, no matter if it is already existent or not. This leads to errors after making unsuccessful POST-requests and prevents the program from saving the corresponding IDs of those nodes.

I propose to solve this, by: 

1. checking if there is already a folder in ES for the corresponding OC instance.
2. if so, fetch all child nodes including metadata
3. in  `src/edu-sharing/create-folders-structure.js` check before each request, if the directory already exists -> if so save node ID
4. in `src/edu-sharing/create-children.js` check before each request, if the episode already exists

This PR adds the possibility to fetch all relevant, existing nodes and currently filters them by type (only folders are kept).
So 1-3 is mostly done. 
The check still needs to be implemented for the episodes. 

We should also discuss, if it makes sense to serialize the fetched data. 

