### PR TITLE
Added possibility to exclude records by id from the import

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ ES_PASSWORD=opencast
   orgName: 'Opencast',
   orgUrl: 'https://opencast.org',
   protocol: 'https',
-  domain: 'develop.opencast.org'
+  domain: 'develop.opencast.org',
+  blacklistedIds: []
 }
 ```
+List Ids of oc-records you don't want to import into edu-sharing in blacklistedIds.
 
 ## Usage
 

--- a/src/config/config.oc-instances.js.template
+++ b/src/config/config.oc-instances.js.template
@@ -3,6 +3,7 @@ module.exports = [
     orgName: 'Opencast',
     orgUrl: 'https://opencast.org',
     protocol: 'https',
-    domain: 'develop.opencast.org'
+    domain: 'develop.opencast.org',
+    blacklistedIds: []
   }
 ]

--- a/src/services/filter-episodes.js
+++ b/src/services/filter-episodes.js
@@ -6,7 +6,10 @@ function filterAllowedLicensedEpisodes(episodes, allowedLicences, ocInstanceObj)
   const episodesWithLicenseInfo = episodes.filter((episode) => episode.dcLicense)
 
   const episodesFiltered = episodesWithLicenseInfo.filter((episode) => {
-    if ('blacklistedIds' in ocInstanceObj && ocInstanceObj['blacklistedIds'].includes(episode.id.toString())) {
+    if (
+      'blacklistedIds' in ocInstanceObj &&
+      ocInstanceObj.blacklistedIds.includes(episode.id.toString())
+    ) {
       return false
     }
     for (let i = 0; i < allowedLicences.length; i++) {

--- a/src/services/filter-episodes.js
+++ b/src/services/filter-episodes.js
@@ -2,10 +2,13 @@
 
 const logger = require('node-file-logger')
 
-function filterAllowedLicensedEpisodes(episodes, allowedLicences) {
+function filterAllowedLicensedEpisodes(episodes, allowedLicences, ocInstanceObj) {
   const episodesWithLicenseInfo = episodes.filter((episode) => episode.dcLicense)
 
   const episodesFiltered = episodesWithLicenseInfo.filter((episode) => {
+    if ('blacklistedIds' in ocInstanceObj && ocInstanceObj['blacklistedIds'].includes(episode.id.toString())) {
+      return false
+    }
     for (let i = 0; i < allowedLicences.length; i++) {
       if (episode.dcLicense.replace(/-/g, ' ') === allowedLicences[i].replace(/-/g, ' ')) {
         return true

--- a/src/workflows/harvestOcInstance.js
+++ b/src/workflows/harvestOcInstance.js
@@ -63,7 +63,11 @@ async function harvestOcInstance(ocInstanceObj, forceUpdate) {
 
     const episodes = await getAllPublishedEpisodes.start(ocEpisodes, forceUpdate, ocInstanceObj)
 
-    ocEpisodes = await filter.filterAllowedLicensedEpisodes(episodes, CONF.filter.allowedLicences, ocInstanceObj)
+    ocEpisodes = await filter.filterAllowedLicensedEpisodes(
+      episodes,
+      CONF.filter.allowedLicences,
+      ocInstanceObj
+    )
     ocSeries = await getSeriesIdsFromEpisodes.start(
       ocEpisodes,
       ocSeries,

--- a/src/workflows/harvestOcInstance.js
+++ b/src/workflows/harvestOcInstance.js
@@ -63,7 +63,7 @@ async function harvestOcInstance(ocInstanceObj, forceUpdate) {
 
     const episodes = await getAllPublishedEpisodes.start(ocEpisodes, forceUpdate, ocInstanceObj)
 
-    ocEpisodes = await filter.filterAllowedLicensedEpisodes(episodes, CONF.filter.allowedLicences)
+    ocEpisodes = await filter.filterAllowedLicensedEpisodes(episodes, CONF.filter.allowedLicences, ocInstanceObj)
     ocSeries = await getSeriesIdsFromEpisodes.start(
       ocEpisodes,
       ocSeries,

--- a/tests/services/filter-episodes.test.js
+++ b/tests/services/filter-episodes.test.js
@@ -15,5 +15,5 @@ test('remove not fitting objects from array', () => {
     { dcLicense: undefined }
   ]
 
-  expect(filter.filterAllowedLicensedEpisodes(episodes, allowedLicences).length).toBe(4)
+  expect(filter.filterAllowedLicensedEpisodes(episodes, allowedLicences, {}).length).toBe(4)
 })


### PR DESCRIPTION
Ref https://github.com/virtUOS/edusharing-opencast-importer/issues/26

Tested on twillo Test -> record with id "5266394031328228000" is filtered and excluded from the import