### PR TITLE
Added possibility to map (non-iso639-1) languages

### DIFF
--- a/src/config/mapping.js
+++ b/src/config/mapping.js
@@ -1,4 +1,7 @@
 module.exports = {
+  language: {
+    'deu': 'de',
+  },
   subjects: {
     'Geschichte': 'https://w3id.org/kim/hochschulfaechersystematik/n05',
     'Informatik': 'https://w3id.org/kim/hochschulfaechersystematik/n71',

--- a/src/edu-sharing/update-metadata.js
+++ b/src/edu-sharing/update-metadata.js
@@ -91,7 +91,7 @@ async function updateMetadata(ocInstance, episodesData) {
       'virtual:primaryparent_nodeid': [episode.parentId],
       'cm:createdISO8601': [episode.created],
       'cclom:general_description': [episode.description],
-      'cclom:general_language': [episode.language],
+      'cclom:general_language': [mapLanguage(episode.language)],
       'cm:edu_forcemetadataset': ['false'],
       'cm:modifier': ['opencast importer'],
       'cm:autoVersionOnUpdateProps': ['false'],
@@ -140,6 +140,13 @@ async function updateMetadata(ocInstance, episodesData) {
     }).toString()
   }
   
+  function mapLanguage(ocLanguage) {
+    if (ocLanguage in MAPPING.language) {
+      return MAPPING.language[ocLanguage]
+    }
+    return ocLanguage
+  }
+
   function mapSubject(ocSubject) {
     if (ocSubject in MAPPING.subjects) {
       return MAPPING.subjects[ocSubject]


### PR DESCRIPTION
Sometimes the value in the `language` field is not an ISO-639-1 code (as required in edu-sharing), but e.g. "deu". Therefore the value has to be adjusted. An idea was to use only the first two characters of the field (or use an iso-639-2 -> iso-639-1 mapping) - but experience has shown that this can lead to errors if users can enter free text here (e.g. "silent movie" or similar). Therefore I implemented the possibility to solve the problem via the mapping configuration.