### PR TITLE
avoid duplicated author information

### DIFF
--- a/src/edu-sharing/update-metadata.js
+++ b/src/edu-sharing/update-metadata.js
@@ -76,7 +76,16 @@ async function updateMetadata(ocInstance, episodesData) {
       .replace(/\s+/g, '_')
       .replace(/-/g, '_')
       .toUpperCase()
-    const authorName = parseFullName(episode.creator)
+    let authors = []
+    if (episode.creators) {
+      if (Array.isArray(episode.creators)) {
+        authors = episode.creators
+      } else {
+        authors = [episode.creators]
+      }
+    } else if (episode.creator) {
+      authors = [episode.creator]
+    }
 
     return JSON.stringify({
       'cm:name': [episode.filename],
@@ -96,18 +105,16 @@ async function updateMetadata(ocInstance, episodesData) {
       'cm:modifier': ['opencast importer'],
       'cm:autoVersionOnUpdateProps': ['false'],
       'cclom:location': ['ccrep://repo/' + episode.nodeId],
-      'ccm:author_freetext': [
-        Array.isArray(episode.creators) ? episode.creators.join('; ') : episode.creators
-      ],
-      'ccm:lifecyclecontributer_author': [
-        parseVCard({
-          title: authorName.title,
-          firstName: authorName.first,
-          middleName: authorName.middle,
-          lastName: authorName.last,
-          formattedName: authorName.formattedName
+      'ccm:lifecyclecontributer_author': authors.map(authorName => {
+        const name = parseFullName(authorName)
+        return parseVCard({
+          title: name.title,
+          firstName: name.first,
+          middleName: name.middle,
+          lastName: name.last,
+          formattedName: name.formattedName
         })
-      ],
+      }),
       'ccm:lifecyclecontributer_publisher': [
         parseVCard({
           organization: episode.organization,


### PR DESCRIPTION
Ref https://github.com/virtUOS/edusharing-opencast-importer/issues/55

* Use just the field `ccm:lifecyclecontributer_author`
* Don't use `ccm:author_freetext` anymore
* in oc metadata there are two fields for creators => prefer the list-field, if available. If not available, use the single-author-field